### PR TITLE
X11 Block Hashing: Use new python extension `dash-hash` now on PyPI

### DIFF
--- a/electrumx/lib/coins.py
+++ b/electrumx/lib/coins.py
@@ -1239,8 +1239,8 @@ class Dash(Coin):
     @classmethod
     def header_hash(cls, header):
         '''Given a header return the hash.'''
-        import x11_hash
-        return x11_hash.getPoWHash(header)
+        import dash_hash
+        return dash_hash.getPoWHash(header)
 
 
 class DashTestnet(Dash):

--- a/electrumx_server
+++ b/electrumx_server
@@ -16,6 +16,12 @@ import sys
 from electrumx import Controller, Env
 from electrumx.lib.util import CompactFormatter, make_logger
 
+def log_hasher_spec(logger):
+    try:
+        import dash_hash
+        logger.debug(dash_hash.__spec__)
+    except ImportError as imp_error:
+        logger.exception('cannot import dash_hash', imp_error.msg)  
 
 def main():
     '''Set up logging and run the server.'''
@@ -31,6 +37,7 @@ def main():
         env = Env()
         logger.info(f'logging level: {env.log_level}')
         logger.setLevel(env.log_level)
+        log_hasher_spec(logger)
         controller = Controller(env)
         asyncio.run(controller.run())
     except Exception:

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,14 @@ setuptools.setup(
     scripts=['electrumx_server', 'electrumx_rpc', 'electrumx_compact_history'],
     python_requires='>=3.7',
     install_requires=['aiorpcX[ws]>=0.18.3,<0.19', 'attrs',
-                      'plyvel', 'pylru', 'aiohttp>=3.3', 'x11-hash>=1.4'],
+                      'plyvel', 'pylru', 'aiohttp>=3.3', 'dash-hash>=1.4'],
     extras_require={
         'rapidjson': ['python-rapidjson>=0.4.1,<1.0.0'],
         'rocksdb': ['python-rocksdb>=0.6.9'],
         'ujson': ['ujson>=2.0.0,<4.0.0'],
         'uvloop': ['uvloop>=0.14'],
         # For various coins
+        'dash-hash': ['dash-hash>=1.4'],
         'blake256': ['blake256>=0.1.1'],
         'crypto': ['pycryptodomex>=3.8.1'],
         'groestl': ['groestlcoin-hash>=1.0.1'],


### PR DESCRIPTION
- Upgraded to work with Python >= 3.10 (#define PY_SSIZE_T_CLEAN)
- Still has some extra debug logging at server startup.